### PR TITLE
Implement gesture controls, video playback enhancements, and i18n updates

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -18,8 +18,8 @@
 **A:** If your taps are being ignored, one of these three system rules is blocking them from reaching the wallpaper:
 
 * **The Lock Screen Blockade:** Gestures will *never* work on the lock screen. Android natively blocks live wallpapers from receiving touch inputs on the lock screen for security reasons. This is a hard, unbypassable OS rule.
-* **Greedy Custom Launchers:** If you use a custom launcher (like Nova, Smart Launcher, Niagara, etc.), it is likely stealing your taps. For example, if your launcher has a "Double tap to turn off screen" feature enabled, it intercepts your fingers before the wallpaper ever feels them. You must disable the launcher's gesture in its own settings to let the taps pass through to the horde.
-* **The Preview Screen:** Gestures are intentionally disabled while you are looking at the system's "Apply Wallpaper" preview screen to prevent hardware bugs on heavily modified Chinese ROMs (like Vivo's Funtouch OS). Apply the wallpaper first, then tap your actual Home Screen.
+* **Greedy Custom Launchers:** If you use a custom launcher (like **Nova**, **Smart Launcher**, **Niagara**, etc.), it is likely stealing your taps. For example, if your launcher has a "Double tap to turn off screen" feature enabled, it intercepts your fingers before the wallpaper ever feels them. You must disable the launcher's gesture in its own settings to let the taps pass through to the horde.
+* **The Preview Screen:** Gestures are intentionally disabled while you are looking at the system's "Apply Wallpaper" preview screen to prevent hardware bugs on certain manufacturer interfaces (like Vivo, Oppo, or Xiaomi). Apply the wallpaper first, then tap your actual Home Screen.
 
 **Q: I have a Xiaomi/POCO/Redmi phone. The video applies to my Home Screen, but my Lock Screen is still static.**
 
@@ -49,3 +49,10 @@
 * **The Battery Killer:** Playing a GIF forces your phone's CPU to manually decode and draw every single frame continuously. Apps that allow this cause massive, silent battery drain.
 * **The Video Advantage:** Actual video files (`.mp4`, `.mkv`) use hardware acceleration. Your phone has a dedicated chip just for decoding video, which is incredibly efficient and uses almost zero extra battery.
 * **The Fix:** If you have a GIF you love, use a free online converter to change it into an `.mp4` file first. Your battery will thank you.
+
+**Q: When I open my app drawer, the background blurs a static image of Zombillie instead of my video. Why?**
+
+**A:** Your phone’s manufacturer is taking a lazy shortcut to save battery. 
+
+* **The Technical Reason:** Blurring live video in real-time requires GPU power. Aggressive custom interfaces (like Infinix's XOS or certain Xiaomi builds) refuse to do this. Instead, their launcher asks the OS for the app's default, hardcoded static thumbnail—our mascot, Zombillie—and just blurs that image instead. 
+* **The Fix:** Because Android requires that fallback thumbnail to be permanently baked into the app's installation file, third-party apps cannot dynamically change it to match your video. To get a true, live video blur, you either have to switch to a well-behaved custom launcher (like **Nova** or **Smart Launcher**) or just embrace your new zombie app drawer companion!

--- a/FAQ.md
+++ b/FAQ.md
@@ -9,9 +9,17 @@
 
 **Q: Can I set a different video for the Lock Screen and the Home Screen?**
 
-**A:** Not currently, and this is due to Android OS limitations. Android's native engine, for a wallpaper running in the background, provide no stable way to detect if it is running in Home or Lock screen.
+**A:** Not currently, and this is due to Android OS limitations. Android's native engine, for a wallpaper running in the background, provides no stable way to detect if it is running on the Home or Lock screen.
 
 * Furthermore, manufacturers like **Asus (ROG UI)** are aggressively hardcoded to override third-party apps, forcing the "Both" behavior. Many custom ROMs lock down the lock screen to force you into their monetized theme stores. The app runs in a sandbox and cannot bypass this.
+
+**Q: I enabled Home Screen Gestures (Double/Triple Tap), but nothing happens when I tap!**
+
+**A:** If your taps are being ignored, one of these three system rules is blocking them from reaching the wallpaper:
+
+* **The Lock Screen Blockade:** Gestures will *never* work on the lock screen. Android natively blocks live wallpapers from receiving touch inputs on the lock screen for security reasons. This is a hard, unbypassable OS rule.
+* **Greedy Custom Launchers:** If you use a custom launcher (like Nova, Smart Launcher, Niagara, etc.), it is likely stealing your taps. For example, if your launcher has a "Double tap to turn off screen" feature enabled, it intercepts your fingers before the wallpaper ever feels them. You must disable the launcher's gesture in its own settings to let the taps pass through to the horde.
+* **The Preview Screen:** Gestures are intentionally disabled while you are looking at the system's "Apply Wallpaper" preview screen to prevent hardware bugs on heavily modified Chinese ROMs (like Vivo's Funtouch OS). Apply the wallpaper first, then tap your actual Home Screen.
 
 **Q: I have a Xiaomi/POCO/Redmi phone. The video applies to my Home Screen, but my Lock Screen is still static.**
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "org.maocide.undeadwallpaper"
         minSdk = 28
         targetSdk = 36
-        versionCode = 38
-        versionName = "1.3.0"
+        versionCode = 39
+        versionName = "1.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         applicationId = "org.maocide.undeadwallpaper"
         minSdk = 28
         targetSdk = 36
-        versionCode = 39
+        versionCode = 40
         versionName = "1.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/org/maocide/undeadwallpaper/data/PlaylistManager.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/data/PlaylistManager.kt
@@ -135,15 +135,8 @@ class PlaylistManager(
             val nextFileName = nextUriParsed.lastPathSegment ?: ""
             val nextSettings = prefs.getVideoSettings(nextFileName)
 
-            // Check if visual settings are identical
-            val isVisualMatch = baseSettings.scalingMode == nextSettings.scalingMode &&
-                    baseSettings.positionX == nextSettings.positionX &&
-                    baseSettings.positionY == nextSettings.positionY &&
-                    baseSettings.zoom == nextSettings.zoom &&
-                    baseSettings.rotation == nextSettings.rotation &&
-                    baseSettings.brightness == nextSettings.brightness
-
-            if (isVisualMatch) {
+            // Check transforms difference in VideoSettings model that would require GL matrix/uniforms updates
+            if (baseSettings.hasSameVisualTransformsAs(nextSettings)) {
                 chunkUris.add(nextUriStr)
             } else {
                 // Settings differ! Break the batch.
@@ -162,13 +155,11 @@ class PlaylistManager(
         val playlistUris = getPlaylistUris()
         if (playlistUris.isEmpty()) return null
 
-        if (playbackMode != PlaybackMode.LOOP_ALL && playbackMode != PlaybackMode.SHUFFLE) {
-            return currentUri // Shouldn't be called, but fallback to same video
-        }
-
         var currentIndex = playlistUris.indexOf(currentUri)
         if (currentIndex == -1) currentIndex = 0
 
+        // Determine the sequence. If SHUFFLE, use shuffle map. Otherwise, use linear.
+        // This allows ONE_SHOT and LOOP to behave like LOOP_ALL when manually skipped.
         val sequenceOrder = if (playbackMode == PlaybackMode.SHUFFLE) {
             getShuffleOrder(playlistUris.size)
         } else {
@@ -181,12 +172,11 @@ class PlaylistManager(
         if (nextPositionInSequence >= playlistUris.size) {
             // We reached the very end of the playlist sequence!
             if (playbackMode == PlaybackMode.SHUFFLE) {
-                // Time to generate a new shuffle order for the next loop
                 regenerateShuffleOrder(playlistUris.size)
                 val newOrder = getShuffleOrder(playlistUris.size)
                 return playlistUris[newOrder[0]]
             } else {
-                // Loop linear back to start
+                // Loop linear back to start (handles LOOP_ALL, LOOP, and ONE_SHOT skips)
                 return playlistUris[0]
             }
         }

--- a/app/src/main/java/org/maocide/undeadwallpaper/data/PlaylistManager.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/data/PlaylistManager.kt
@@ -86,8 +86,7 @@ class PlaylistManager(
      * If a video requires a visual change, the chunk ends, forcing the player to
      * hit a playback boundary so the renderer can safely apply the new settings.
      */
-    fun getGaplessChunkUris(currentUri: String, playbackMode: PlaybackMode): List<String> {
-        val playlistUris = getPlaylistUris()
+    fun getGaplessChunkUris(currentUri: String, playbackMode: PlaybackMode, playlistUris: List<String> = getPlaylistUris()): List<String> {
         if (playlistUris.isEmpty()) return emptyList()
 
         val chunkUris = mutableListOf<String>()

--- a/app/src/main/java/org/maocide/undeadwallpaper/data/PreferencesManager.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/data/PreferencesManager.kt
@@ -13,6 +13,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import android.net.Uri
+import org.maocide.undeadwallpaper.model.GestureType
+import org.maocide.undeadwallpaper.model.WallpaperAction
 
 /**
  * Manages SharedPreferences for the application.
@@ -49,6 +51,10 @@ class PreferencesManager(context: Context) {
 
         private const val KEY_RECENT_FILES_LIST = "recent_files_list"
         private const val KEY_PLAYLIST_SETTINGS = "playlist_settings"
+
+        private const val KEY_ACTION_DOUBLE_TAP = "action_double_tap"
+
+        private const val KEY_ACTION_LONG_PRESS = "action_long_press"
     }
 
     init {
@@ -291,6 +297,28 @@ class PreferencesManager(context: Context) {
 
     fun isLoggingEnabled(): Boolean {
         return sharedPrefs.getBoolean(KEY_LOGGING_ENABLED, false)
+    }
+
+    /**
+     * Gets the action bound to a specific gesture.
+     * Default for ALL gestures is NONE.
+     */
+    fun getActionForGesture(gesture: GestureType): WallpaperAction {
+        val key = when (gesture) {
+            GestureType.DOUBLE_TAP -> KEY_ACTION_DOUBLE_TAP
+            GestureType.LONG_PRESS -> KEY_ACTION_LONG_PRESS
+        }
+
+        val storedOrdinal = sharedPrefs.getInt(key, WallpaperAction.NONE.ordinal)
+        return WallpaperAction.entries.getOrElse(storedOrdinal) { WallpaperAction.NONE }
+    }
+
+    fun setActionForGesture(gesture: GestureType, action: WallpaperAction) {
+        val key = when (gesture) {
+            GestureType.DOUBLE_TAP -> KEY_ACTION_DOUBLE_TAP
+            GestureType.LONG_PRESS -> KEY_ACTION_LONG_PRESS
+        }
+        sharedPrefs.edit { putInt(key, action.ordinal) }
     }
 
 }

--- a/app/src/main/java/org/maocide/undeadwallpaper/data/PreferencesManager.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/data/PreferencesManager.kt
@@ -54,6 +54,8 @@ class PreferencesManager(context: Context) {
 
         private const val KEY_ACTION_DOUBLE_TAP = "action_double_tap"
 
+        private const val KEY_ACTION_TRIPLE_TAP = "action_triple_tap"
+
         private const val KEY_ACTION_LONG_PRESS = "action_long_press"
     }
 
@@ -306,7 +308,7 @@ class PreferencesManager(context: Context) {
     fun getActionForGesture(gesture: GestureType): WallpaperAction {
         val key = when (gesture) {
             GestureType.DOUBLE_TAP -> KEY_ACTION_DOUBLE_TAP
-            GestureType.LONG_PRESS -> KEY_ACTION_LONG_PRESS
+            GestureType.TRIPLE_TAP -> KEY_ACTION_TRIPLE_TAP
         }
 
         val storedOrdinal = sharedPrefs.getInt(key, WallpaperAction.NONE.ordinal)
@@ -316,7 +318,7 @@ class PreferencesManager(context: Context) {
     fun setActionForGesture(gesture: GestureType, action: WallpaperAction) {
         val key = when (gesture) {
             GestureType.DOUBLE_TAP -> KEY_ACTION_DOUBLE_TAP
-            GestureType.LONG_PRESS -> KEY_ACTION_LONG_PRESS
+            GestureType.TRIPLE_TAP -> KEY_ACTION_TRIPLE_TAP
         }
         sharedPrefs.edit { putInt(key, action.ordinal) }
     }

--- a/app/src/main/java/org/maocide/undeadwallpaper/data/PreferencesManager.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/data/PreferencesManager.kt
@@ -29,6 +29,9 @@ class PreferencesManager(context: Context) {
 
     private val jsonParser = Json { ignoreUnknownKeys = true }
 
+    private var cachedPlaylistSettingsString: String? = null
+    private var cachedPlaylistSettings: List<VideoSettings>? = null
+
     companion object {
         private const val PREFS_NAME = "DEFAULT"
         private const val KEY_VIDEO_URI = "video_uri"
@@ -158,13 +161,26 @@ class PreferencesManager(context: Context) {
         }
     }
 
+    /**
+     * Getter for playlist video settings implementing a caching to avoid json decoding each call.
+     * the cache is updated/invalidated by the save method.
+     */
     fun getPlaylistSettings(): List<VideoSettings> {
         val jsonString = sharedPrefs.getString(KEY_PLAYLIST_SETTINGS, null)
         if (jsonString.isNullOrBlank()) {
+            cachedPlaylistSettingsString = null
+            cachedPlaylistSettings = null
             return emptyList()
         }
+        val cachedSettings = cachedPlaylistSettings
+        if (jsonString == cachedPlaylistSettingsString && cachedSettings != null) {
+            return cachedSettings
+        }
         return try {
-            jsonParser.decodeFromString<List<VideoSettings>>(jsonString)
+            val decoded = jsonParser.decodeFromString<List<VideoSettings>>(jsonString)
+            cachedPlaylistSettingsString = jsonString
+            cachedPlaylistSettings = decoded
+            decoded
         } catch (e: Exception) {
             emptyList()
         }
@@ -172,6 +188,8 @@ class PreferencesManager(context: Context) {
 
     fun savePlaylistSettings(playlist: List<VideoSettings>) {
         val jsonString = jsonParser.encodeToString(playlist)
+        cachedPlaylistSettingsString = jsonString
+        cachedPlaylistSettings = playlist
         sharedPrefs.edit(commit = true)
         { putString(KEY_PLAYLIST_SETTINGS, jsonString) }
     }

--- a/app/src/main/java/org/maocide/undeadwallpaper/input/GestureManager.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/input/GestureManager.kt
@@ -1,0 +1,73 @@
+package org.maocide.undeadwallpaper.input
+
+import android.os.Handler
+import android.os.Looper
+import android.view.MotionEvent
+import org.maocide.undeadwallpaper.data.PreferencesManager
+import org.maocide.undeadwallpaper.model.GestureType
+import org.maocide.undeadwallpaper.model.WallpaperAction
+import org.maocide.undeadwallpaper.utils.FileLogger
+
+class WallpaperGestureManager(
+    private val prefs: PreferencesManager,
+    private val onActionTriggered: (WallpaperAction) -> Unit
+) {
+    private val TAG = javaClass.simpleName
+    private var tapCount = 0
+    private var lastTapTimeMs = 0L
+    private val TAP_TIMEOUT_MS = 300L
+    private val handler = Handler(Looper.getMainLooper())
+
+    private val tapResolutionRunnable = Runnable {
+        if (tapCount == 2) {
+            FileLogger.i(TAG, "Confirmed DOUBLE TAP")
+            // Get and trigger action
+            val action = prefs.getActionForGesture(GestureType.DOUBLE_TAP)
+            onActionTriggered(action)
+        }
+        resetTapState()
+    }
+
+    fun onTouchEvent(event: MotionEvent?) {
+        if (event?.action == MotionEvent.ACTION_DOWN) {
+            val currentTapTimeMs = System.currentTimeMillis()
+
+            if (currentTapTimeMs - lastTapTimeMs > TAP_TIMEOUT_MS) {
+                // First tap, or too much time passed
+                tapCount = 1
+            } else {
+                tapCount++
+            }
+
+            lastTapTimeMs = currentTapTimeMs
+
+            // Cancel any pending resolution because a new tap arrived!
+            handler.removeCallbacks(tapResolutionRunnable)
+
+            if (tapCount == 3) {
+                // TRIPLE TAP DETECTED! Execute immediately.
+                FileLogger.i(TAG, "Confirmed TRIPLE TAP")
+
+                // Reset immediately so a 4th rapid tap doesn't trigger anything weird
+                resetTapState()
+
+                // Get and trigger action
+                val action = prefs.getActionForGesture(GestureType.TRIPLE_TAP)
+                onActionTriggered(action)
+            } else {
+                // Tap 1 or 2. Wait to see if another tap comes.
+                handler.postDelayed(tapResolutionRunnable, TAP_TIMEOUT_MS)
+            }
+        }
+    }
+
+    fun destroy() {
+        handler.removeCallbacks(tapResolutionRunnable)
+        resetTapState()
+    }
+
+    private fun resetTapState() {
+        tapCount = 0
+        lastTapTimeMs = 0L
+    }
+}

--- a/app/src/main/java/org/maocide/undeadwallpaper/model/GestureType.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/model/GestureType.kt
@@ -1,0 +1,6 @@
+package org.maocide.undeadwallpaper.model
+
+enum class GestureType {
+    DOUBLE_TAP,
+    LONG_PRESS
+}

--- a/app/src/main/java/org/maocide/undeadwallpaper/model/GestureType.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/model/GestureType.kt
@@ -2,5 +2,5 @@ package org.maocide.undeadwallpaper.model
 
 enum class GestureType {
     DOUBLE_TAP,
-    LONG_PRESS
+    TRIPLE_TAP,
 }

--- a/app/src/main/java/org/maocide/undeadwallpaper/model/VideoSettings.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/model/VideoSettings.kt
@@ -68,6 +68,20 @@ data class VideoSettings(
     }
 
     /**
+     * Checks if this video shares the exact same OpenGL visual transforms as another video.
+     * This is used to determine if ExoPlayer can gapless-transition between them without
+     * a visual snap from the renderer matrix updating.
+     */
+    fun hasSameVisualTransformsAs(other: VideoSettings): Boolean {
+        return this.scalingMode == other.scalingMode &&
+                this.positionX == other.positionX &&
+                this.positionY == other.positionY &&
+                this.zoom == other.zoom &&
+                this.rotation == other.rotation &&
+                this.brightness == other.brightness
+    }
+
+    /**
      * Applies a quadratic curve to the linear volume slider value.
      * This mimics the logarithmic perception of human hearing.
      */

--- a/app/src/main/java/org/maocide/undeadwallpaper/model/WallpaperAction.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/model/WallpaperAction.kt
@@ -1,0 +1,7 @@
+package org.maocide.undeadwallpaper.model
+
+enum class WallpaperAction {
+    NONE,
+    SKIP_NEXT,
+    PLAY_PAUSE
+}

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -521,7 +521,8 @@ class UndeadWallpaperService : WallpaperService() {
             bindPlaylistToPlayer(keepCurrentPlayback = false)
 
             // Send all values to renderer updating it, will be used for matrix calc.
-            refreshRenderer()
+            // refreshRenderer() // Removed from initialization, as it's called on first frame
+            // it will be better there to sync better with video switching on touch events.
 
             // WAIT for the GL Surface, then attach
             playerSetupJob = kotlinx.coroutines.CoroutineScope(Dispatchers.Main).launch {
@@ -604,7 +605,6 @@ class UndeadWallpaperService : WallpaperService() {
         }
 
         /**
-         * Helper method to keep it DRY (Don't Repeat Yourself)
          * Releases the [GLVideoRenderer] and its associated resources.
          * This should be called when the underlying surface is destroyed.
          * It ensures that OpenGL contexts and other graphics-related

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -25,6 +25,7 @@ import android.os.Looper
 import android.os.UserManager
 import android.service.wallpaper.WallpaperService
 import android.util.Log
+import android.view.MotionEvent
 
 
 import android.view.SurfaceHolder
@@ -50,8 +51,9 @@ import androidx.media3.exoplayer.upstream.DefaultAllocator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-
-
+import org.maocide.undeadwallpaper.model.GestureType
+import org.maocide.undeadwallpaper.model.VideoSettings
+import org.maocide.undeadwallpaper.model.WallpaperAction
 
 
 import kotlin.math.log
@@ -115,6 +117,46 @@ class UndeadWallpaperService : WallpaperService() {
         }
 
         private var visibilityJob: kotlinx.coroutines.Job? = null
+
+        // Touch Interaction State
+        private var lastTapTimeMs: Long = 0L
+        private var tapCount: Int = 0
+        private val DOUBLE_TAP_TIMEOUT_MS = 300L // Standard Android double-tap window
+        private val touchHandler = Handler(Looper.getMainLooper())
+
+        private val resetTapCountRunnable = Runnable {
+            tapCount = 0
+            lastTapTimeMs = 0L
+        }
+
+        private fun applyNonVisualSettings(settings: VideoSettings) {
+            wallpaperPlayer.getPlayerInstance()?.let { player ->
+                player.volume = settings.getPerceivedVolume()
+                player.setPlaybackSpeed(settings.speed)
+            }
+        }
+
+        private fun getSettingsForUri(uriString: String): VideoSettings {
+            val fileName = uriString.toUri().lastPathSegment ?: ""
+            return prefs.getVideoSettings(fileName)
+        }
+
+        private fun updateActiveVideoState(newUriString: String) {
+            loadedVideoUriString = newUriString
+            prefs.saveActiveVideoUri(newUriString)
+        }
+
+        private fun updateTouchListeningState() {
+            val doubleTapAction = prefs.getActionForGesture(GestureType.DOUBLE_TAP)
+            val longPressAction = prefs.getActionForGesture(GestureType.LONG_PRESS)
+
+            // Only turn on the Android touch pipeline if the user actually bound an action
+            val wantsTouchEvents = doubleTapAction != WallpaperAction.NONE || longPressAction != WallpaperAction.NONE
+
+            setTouchEventsEnabled(wantsTouchEvents)
+            FileLogger.i(TAG, "Touch events enabled: $wantsTouchEvents")
+        }
+
 
         @OptIn(UnstableApi::class)
         private fun bindPlaylistToPlayer(keepCurrentPlayback: Boolean) {
@@ -206,14 +248,115 @@ class UndeadWallpaperService : WallpaperService() {
             }
         }
 
-        private fun refreshRenderer() {
-            if (loadedVideoUriString.isBlank()) return
+        /**
+         * Skips current video and moves to next using chunks to buffer video sharing settings
+         */
+        private fun skipNextVideo(isManualSkip: Boolean) {
+            if (!isPlayerInitialized) return
+
+            val nextUriString = playlistManager.getNextUri(loadedVideoUriString, currentPlaybackMode)
+
+            if (nextUriString == null) {
+                FileLogger.w(TAG, "Transition aborted: Next URI is null.")
+                return
+            }
+
+            FileLogger.i(TAG, "Transitioning across boundary to: $nextUriString (Manual: $isManualSkip)")
+
+            // ONE_SHOT / LOOP Reset (These still need a hard re-init to reset their single-video state)
+            if (currentPlaybackMode == PlaybackMode.ONE_SHOT || currentPlaybackMode == PlaybackMode.LOOP) {
+                loadedVideoUriString = nextUriString
+                prefs.saveActiveVideoUri(nextUriString)
+
+                FileLogger.i(TAG, "Single-video mode detected. Performing hard re-initialization for skip.")
+                releasePlayer()
+                playheadTime = 0L
+                hasPlaybackCompleted = false
+                initializePlayer()
+                return
+            }
+
+            // Now update the state
+            loadedVideoUriString = nextUriString
+            prefs.saveActiveVideoUri(nextUriString)
+            playheadTime = 0L
+            hasPlaybackCompleted = false
+
+            // ALWAYS Hot-swap via Chunking!
+            bindPlaylistToPlayer(keepCurrentPlayback = false)
+
+            if (!isManualSkip) {
+                // AUTOMATIC TRANSITION (STATE_ENDED):
+                // The decoder buffer is completely empty. We MUST apply the matrix NOW
+                // so the very first frame of the new video draws perfectly.
+                FileLogger.i(TAG, "Auto-transition: Applying matrix immediately.")
+                refreshRenderer()
+            } else {
+                // MANUAL SKIP:
+                // The buffer has old frames. We DELAY the matrix update until
+                // onRenderedFirstFrame fires to prevent a visual snap.
+                FileLogger.i(TAG, "Manual skip: Delaying matrix update to onRenderedFirstFrame.")
+            }
 
             val activeUri = loadedVideoUriString.toUri()
             val fileName = activeUri.lastPathSegment ?: ""
             val activeSettings = prefs.getVideoSettings(fileName)
 
-            // Send the whole package to the renderer
+            wallpaperPlayer.getPlayerInstance()?.let { player ->
+                player.volume = activeSettings.getPerceivedVolume()
+                player.setPlaybackSpeed(activeSettings.speed)
+            }
+
+            wallpaperPlayer.prepare()
+            wallpaperPlayer.playWhenReady = if (isManualSkip) isVisible else true
+        }
+
+        override fun onTouchEvent(event: MotionEvent?) {
+            super.onTouchEvent(event)
+
+            // We only care about the moment the finger hits the screen
+            if (event?.action == MotionEvent.ACTION_DOWN) {
+                val currentTapTimeMs = System.currentTimeMillis()
+
+                // If this tap is within the timeout window of the previous tap
+                if (currentTapTimeMs - lastTapTimeMs < DOUBLE_TAP_TIMEOUT_MS) {
+                    tapCount++
+                } else {
+                    // First tap, or too much time passed. Reset count.
+                    tapCount = 1
+                }
+
+                lastTapTimeMs = currentTapTimeMs
+
+                // Cancel any pending reset
+                touchHandler.removeCallbacks(resetTapCountRunnable)
+
+                if (tapCount == 2) {
+                    // DOUBLE TAP DETECTED!
+                    FileLogger.i(TAG, "Double-tap detected at X:${event.x}, Y:${event.y}")
+
+                    // Reset immediately so a third rapid tap doesn't trigger it again
+                    tapCount = 0
+                    lastTapTimeMs = 0L
+
+                    skipNextVideo(true)
+                } else {
+                    // If it's just a single tap, wait to see if a second one comes.
+                    // If not, reset the counter.
+                    touchHandler.postDelayed(resetTapCountRunnable, DOUBLE_TAP_TIMEOUT_MS)
+                }
+            }
+        }
+
+        /**
+         * Uses the VideoSettings of the current uri to recompute matrix/uniforms on GL Renderer
+         * It is done here to be as late and synced to playback as possible.
+         */
+        private fun refreshRenderer() {
+            if (loadedVideoUriString.isBlank()) return
+
+            val activeSettings = getSettingsForUri(loadedVideoUriString)
+
             currentScalingMode = activeSettings.scalingMode
             renderer?.setScalingMode(currentScalingMode)
             renderer?.setTransforms(
@@ -259,8 +402,8 @@ class UndeadWallpaperService : WallpaperService() {
             // Send video size to Renderer for Matrix Calculation
             renderer?.setVideoSize(width, height)
 
-            // refresh all user values to renderer
-            refreshRenderer()
+            // No more refreshed here, just on new frame
+            // refreshRenderer()
 
             // Use ExoPlayer's scaling only if fallback surface is used
             if (useFallbackSurface) {
@@ -290,34 +433,8 @@ class UndeadWallpaperService : WallpaperService() {
                         hasPlaybackCompleted = true
                         wallpaperPlayer.pause()
                     } else if (currentPlaybackMode == PlaybackMode.LOOP_ALL || currentPlaybackMode == PlaybackMode.SHUFFLE) {
-                        // Manual playlist boundary handling
-                        // The playback ended because we reached the end of a chunk of identical-settings videos.
-                        // We must load the NEXT chunk starting from the video after the one that just finished.
-                        val nextUriString = playlistManager.getNextUri(loadedVideoUriString, currentPlaybackMode)
-                        if (nextUriString != null) {
-                            FileLogger.i(TAG, "Manually transitioning across settings boundary to: $nextUriString")
-
-                            loadedVideoUriString = nextUriString
-                            prefs.saveActiveVideoUri(nextUriString)
-
-                            playheadTime = 0L
-                            hasPlaybackCompleted = false
-
-                            // Load the next chunk and flush the player
-                            bindPlaylistToPlayer(keepCurrentPlayback = false)
-                            refreshRenderer()
-
-                            val activeUri = loadedVideoUriString.toUri()
-                            val fileName = activeUri.lastPathSegment ?: ""
-                            val activeSettings = prefs.getVideoSettings(fileName)
-                            wallpaperPlayer.getPlayerInstance()?.let { player ->
-                                player.volume = activeSettings.getPerceivedVolume()
-                                player.setPlaybackSpeed(activeSettings.speed)
-                            }
-
-                            wallpaperPlayer.prepare()
-                            wallpaperPlayer.playWhenReady = true
-                        }
+                        // Same flow as skip, inside the playback mode is handled
+                        skipNextVideo(isManualSkip = false)
                     }
                 }
                 Player.STATE_READY -> {
@@ -330,27 +447,19 @@ class UndeadWallpaperService : WallpaperService() {
 
         @OptIn(UnstableApi::class)
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            // Track chunk advancement internally
+            // Track chunk advancement internally for optimized batching
             val nextUriString = mediaItem?.mediaId
             if (nextUriString != null && nextUriString != loadedVideoUriString) {
-                FileLogger.i(TAG, "Chunk transition: advancing internally to $nextUriString")
-                loadedVideoUriString = nextUriString
-                prefs.saveActiveVideoUri(nextUriString)
+                updateActiveVideoState(nextUriString)
             }
 
-            // Update non-visual settings (volume, speed) dynamically during the chunk
-            val activeUri = loadedVideoUriString.toUri()
-            val fileName = activeUri.lastPathSegment ?: ""
-            val activeSettings = prefs.getVideoSettings(fileName)
-
-            wallpaperPlayer.getPlayerInstance()?.let { player ->
-                player.volume = activeSettings.getPerceivedVolume()
-                player.setPlaybackSpeed(activeSettings.speed)
-            }
+            val activeSettings = getSettingsForUri(loadedVideoUriString)
+            applyNonVisualSettings(activeSettings)
         }
 
         override fun onRenderedFirstFrame() {
             FileLogger.i(TAG, "SUCCESS: onRenderedFirstFrame called. Decoder actually pushed a frame to the screen!")
+            refreshRenderer() // Applies as late as possible a matrix/uniform recomputation on openGL engine
         }
 
         @OptIn(UnstableApi::class)
@@ -698,6 +807,10 @@ class UndeadWallpaperService : WallpaperService() {
         override fun onCreate(surfaceHolder: SurfaceHolder) {
             super.onCreate(surfaceHolder)
             FileLogger.i(TAG, "Engine onCreate")
+
+            // Allow the OS to send MotionEvents to this engine
+            setTouchEventsEnabled(true)
+
             // Turn on filter to start listening
             val intentFilter = IntentFilter().apply {
                 addAction(ACTION_VIDEO_URI_CHANGED)

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -266,6 +266,7 @@ class UndeadWallpaperService : WallpaperService() {
                     // Will be called by changing video
                     ACTION_VIDEO_URI_CHANGED -> {
                         FileLogger.i(TAG, "Broadcast received: Video uri changed, full re-initialization requested.")
+                        isUserManuallyPaused = false // CLEAR PAUSE STATE
                         resetPlaybackTimeline()
                         initializePlayer() // force Reinit
                     }
@@ -273,6 +274,7 @@ class UndeadWallpaperService : WallpaperService() {
                     // Will be called by changing scaling, playback mode, all things requiring a reinit
                     ACTION_PLAYBACK_MODE_CHANGED -> {
                         FileLogger.i(TAG, "Broadcast received: Playback mode change, full re-initialization requested.")
+                        isUserManuallyPaused = false // CLEAR PAUSE STATE
                         resetPlaybackTimeline()
                         initializePlayer() // force Reinit
                     }
@@ -295,6 +297,7 @@ class UndeadWallpaperService : WallpaperService() {
 
                     ACTION_VIDEO_SETTINGS_CHANGED -> {
                         FileLogger.i(TAG, "Broadcast received: Video settings changed, full re-initialization requested.")
+                        isUserManuallyPaused = false // CLEAR PAUSE STATE
                         // Ensure settings apply completely identical to a URI change to avoid syncing bugs
                         resetPlaybackTimeline()
                         initializePlayer() // force Reinit

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -218,9 +218,11 @@ class UndeadWallpaperService : WallpaperService() {
 
             val mediaUri = getMediaUri() ?: return
 
+            val playlistUris = playlistManager.getPlaylistUris()
+
             // Hybrid Gapless Batching:
             // Fetch the chunk of consecutive URIs that share identical visual settings.
-            val chunkUris = playlistManager.getGaplessChunkUris(loadedVideoUriString, currentPlaybackMode)
+            val chunkUris = playlistManager.getGaplessChunkUris(loadedVideoUriString, currentPlaybackMode, playlistUris)
 
             // If the chunk is empty for some reason, fallback to the single mediaUri
             val urisToLoad = if (chunkUris.isNotEmpty()) chunkUris else listOf(loadedVideoUriString)
@@ -236,7 +238,6 @@ class UndeadWallpaperService : WallpaperService() {
             // We can safely enable ExoPlayer's internal REPEAT_MODE_ALL. This gives perfect gapless looping
             // without ever hitting STATE_ENDED and incurring the manual flush pause.
             // NOTE: SHUFFLE mode is excluded because it MUST hit STATE_ENDED to trigger a newly randomized sequence loop.
-            val playlistUris = playlistManager.getPlaylistUris()
             if (currentPlaybackMode == PlaybackMode.LOOP_ALL
                 && playlistUris.isNotEmpty() && chunkUris.size == playlistUris.size) {
                 wallpaperPlayer.setRepeatMode(Player.REPEAT_MODE_ALL)

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -169,9 +169,16 @@ class UndeadWallpaperService : WallpaperService() {
             val doubleTapAction = prefs.getActionForGesture(GestureType.DOUBLE_TAP)
             val tripleTapAction = prefs.getActionForGesture(GestureType.TRIPLE_TAP)
 
+            // EDGE CASE: If the video is manually paused, but the user just removed
+            // the PLAY_PAUSE action from all gestures, we must unpause it so they don't get stuck
+            val canPause = doubleTapAction == WallpaperAction.PLAY_PAUSE || tripleTapAction == WallpaperAction.PLAY_PAUSE
+            if (isUserManuallyPaused && !canPause) {
+                isUserManuallyPaused = false
+                FileLogger.i(TAG, "Play/Pause action unbound. Clearing manual pause state.")
+            }
+
             // VIVO AND CHINESE PHONES FIX: Never request touch events while in the system preview screen,
             // otherwise Vivo's OS sends the "Apply Wallpaper" button taps to us instead of the system.
-            // Checking isPreview flag should solve.
             val wantsTouchEvents = !isPreview && (doubleTapAction != WallpaperAction.NONE || tripleTapAction != WallpaperAction.NONE)
 
             // ONLY tell the OS to change the touch state if it's different from the current state.

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -121,6 +121,7 @@ class UndeadWallpaperService : WallpaperService() {
 
         // Touch Interaction State
         private var isUserManuallyPaused = false
+        private var isCurrentlyListeningForTouch = true // Engine onCreate defaults to true
 
         // Initialize our new clean manager
         private val gestureManager = WallpaperGestureManager(prefs) { action ->
@@ -168,11 +169,17 @@ class UndeadWallpaperService : WallpaperService() {
             val doubleTapAction = prefs.getActionForGesture(GestureType.DOUBLE_TAP)
             val tripleTapAction = prefs.getActionForGesture(GestureType.TRIPLE_TAP)
 
-            // Only turn on the Android touch pipeline if the user actually bound an action
-            val wantsTouchEvents = doubleTapAction != WallpaperAction.NONE || tripleTapAction != WallpaperAction.NONE
+            // VIVO AND CHINESE PHONES FIX: Never request touch events while in the system preview screen,
+            // otherwise Vivo's OS sends the "Apply Wallpaper" button taps to us instead of the system.
+            // Checking isPreview flag should solve.
+            val wantsTouchEvents = !isPreview && (doubleTapAction != WallpaperAction.NONE || tripleTapAction != WallpaperAction.NONE)
 
-            setTouchEventsEnabled(wantsTouchEvents)
-            FileLogger.i(TAG, "Touch events enabled: $wantsTouchEvents")
+            // ONLY tell the OS to change the touch state if it's different from the current state.
+            if (isCurrentlyListeningForTouch != wantsTouchEvents) {
+                setTouchEventsEnabled(wantsTouchEvents)
+                isCurrentlyListeningForTouch = wantsTouchEvents
+                FileLogger.i(TAG, "Touch events enabled changed to: $wantsTouchEvents")
+            }
         }
 
         private fun executeGestureAction(action: WallpaperAction) {
@@ -343,14 +350,8 @@ class UndeadWallpaperService : WallpaperService() {
                 FileLogger.i(TAG, "Manual skip: Delaying matrix update to onRenderedFirstFrame.")
             }
 
-            val activeUri = loadedVideoUriString.toUri()
-            val fileName = activeUri.lastPathSegment ?: ""
-            val activeSettings = prefs.getVideoSettings(fileName)
-
-            wallpaperPlayer.getPlayerInstance()?.let { player ->
-                player.volume = activeSettings.getPerceivedVolume()
-                player.setPlaybackSpeed(activeSettings.speed)
-            }
+            val activeSettings = getSettingsForUri(loadedVideoUriString)
+            applyNonVisualSettings(activeSettings)
 
             wallpaperPlayer.prepare()
             wallpaperPlayer.playWhenReady = if (isManualSkip) isVisible else true
@@ -358,6 +359,12 @@ class UndeadWallpaperService : WallpaperService() {
 
         override fun onTouchEvent(event: MotionEvent?) {
             super.onTouchEvent(event)
+
+            // If we actively decided we don't want touches, ignore any ghost touches
+            // the Android OS accidentally forwards to us anyway.
+            // Most likely needed too for VIVO and CHINESE phones.
+            if (!isCurrentlyListeningForTouch) return
+
             gestureManager.onTouchEvent(event)
         }
 
@@ -676,8 +683,15 @@ class UndeadWallpaperService : WallpaperService() {
             FileLogger.i(TAG, "onSurfaceCreated")
             this.surfaceHolder = holder
 
+            // VIVO SHIELD: Funtouch OS spams onSurfaceCreated when touch events change,
+            // WITHOUT calling onSurfaceDestroyed first.
+            // If we already have a renderer, the surface is still perfectly valid. Ignore the spam!
+            if (renderer != null) {
+                FileLogger.w(TAG, "Vivo spam detected: onSurfaceCreated called but renderer exists. Ignoring.")
+                return
+            }
+
             if (!useFallbackSurface) {
-                // Start the GL Renderer
                 renderer = GLVideoRenderer(applicationContext)
                 renderer?.onSurfaceCreated(holder)
             } else {
@@ -818,9 +832,6 @@ class UndeadWallpaperService : WallpaperService() {
         override fun onCreate(surfaceHolder: SurfaceHolder) {
             super.onCreate(surfaceHolder)
             FileLogger.i(TAG, "Engine onCreate")
-
-            // Allow the OS to send MotionEvents to this engine
-            setTouchEventsEnabled(true)
 
             // Turn on filter to start listening
             val intentFilter = IntentFilter().apply {

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -51,6 +51,7 @@ import androidx.media3.exoplayer.upstream.DefaultAllocator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import org.maocide.undeadwallpaper.input.WallpaperGestureManager
 import org.maocide.undeadwallpaper.model.GestureType
 import org.maocide.undeadwallpaper.model.VideoSettings
 import org.maocide.undeadwallpaper.model.WallpaperAction
@@ -119,16 +120,29 @@ class UndeadWallpaperService : WallpaperService() {
         private var visibilityJob: kotlinx.coroutines.Job? = null
 
         // Touch Interaction State
-        private var lastTapTimeMs: Long = 0L
-        private var tapCount: Int = 0
-        private val DOUBLE_TAP_TIMEOUT_MS = 300L // Standard Android double-tap window
-        private val touchHandler = Handler(Looper.getMainLooper())
+        private var isUserManuallyPaused = false
 
-        private val resetTapCountRunnable = Runnable {
-            tapCount = 0
-            lastTapTimeMs = 0L
+        // Initialize our new clean manager
+        private val gestureManager = WallpaperGestureManager(prefs) { action ->
+            executeGestureAction(action)
         }
 
+        /**
+         * Resets the internal playback timeline variables.
+         * @param seekPlayerToStart If true, also forces the active ExoPlayer instance to rewind to the beginning.
+         */
+        private fun resetPlaybackTimeline(seekPlayerToStart: Boolean = false) {
+            playheadTime = 0L
+            hasPlaybackCompleted = false
+            if (seekPlayerToStart) {
+                wallpaperPlayer.seekToDefaultPosition()
+            }
+        }
+
+        /**
+         * Applies VideoSettings that don't require a GL Renderer Update. Volume, speed...
+         * @param settings VideoSettings object from which to apply non-visual settings
+         */
         private fun applyNonVisualSettings(settings: VideoSettings) {
             wallpaperPlayer.getPlayerInstance()?.let { player ->
                 player.volume = settings.getPerceivedVolume()
@@ -136,6 +150,10 @@ class UndeadWallpaperService : WallpaperService() {
             }
         }
 
+        /**
+         * Retrieves VideoSettings for the provided uri String.
+         * @param uriString the uri string of the video to get settings from.
+         */
         private fun getSettingsForUri(uriString: String): VideoSettings {
             val fileName = uriString.toUri().lastPathSegment ?: ""
             return prefs.getVideoSettings(fileName)
@@ -148,15 +166,43 @@ class UndeadWallpaperService : WallpaperService() {
 
         private fun updateTouchListeningState() {
             val doubleTapAction = prefs.getActionForGesture(GestureType.DOUBLE_TAP)
-            val longPressAction = prefs.getActionForGesture(GestureType.LONG_PRESS)
+            val tripleTapAction = prefs.getActionForGesture(GestureType.TRIPLE_TAP)
 
             // Only turn on the Android touch pipeline if the user actually bound an action
-            val wantsTouchEvents = doubleTapAction != WallpaperAction.NONE || longPressAction != WallpaperAction.NONE
+            val wantsTouchEvents = doubleTapAction != WallpaperAction.NONE || tripleTapAction != WallpaperAction.NONE
 
             setTouchEventsEnabled(wantsTouchEvents)
             FileLogger.i(TAG, "Touch events enabled: $wantsTouchEvents")
         }
 
+        private fun executeGestureAction(action: WallpaperAction) {
+            when (action) {
+                WallpaperAction.NONE -> return
+
+                WallpaperAction.SKIP_NEXT -> {
+                    // UX Rule: If they skip, they want to see the new video. Unpause it.
+                    isUserManuallyPaused = false
+                    skipNextVideo(isManualSkip = true)
+                }
+
+                WallpaperAction.PLAY_PAUSE -> {
+                    if (!isPlayerInitialized) return
+
+                    // ONE_SHOT CASE: If they "Play" a finished video, restart it!
+                    if (currentPlaybackMode == PlaybackMode.ONE_SHOT && hasPlaybackCompleted) {
+                        FileLogger.i(TAG, "User triggered Play on a finished ONE_SHOT video. Replaying.")
+                        resetPlaybackTimeline(seekPlayerToStart = true)
+                        isUserManuallyPaused = false
+                    } else {
+                        // Normal toggle behavior
+                        isUserManuallyPaused = !isUserManuallyPaused
+                    }
+
+                    wallpaperPlayer.playWhenReady = !isUserManuallyPaused
+                    FileLogger.i(TAG, "User toggled Play/Pause. isUserManuallyPaused: $isUserManuallyPaused")
+                }
+            }
+        }
 
         @OptIn(UnstableApi::class)
         private fun bindPlaylistToPlayer(keepCurrentPlayback: Boolean) {
@@ -205,14 +251,14 @@ class UndeadWallpaperService : WallpaperService() {
                     // Will be called by changing video
                     ACTION_VIDEO_URI_CHANGED -> {
                         FileLogger.i(TAG, "Broadcast received: Video uri changed, full re-initialization requested.")
-                        playheadTime = 0L
+                        resetPlaybackTimeline()
                         initializePlayer() // force Reinit
                     }
 
                     // Will be called by changing scaling, playback mode, all things requiring a reinit
                     ACTION_PLAYBACK_MODE_CHANGED -> {
                         FileLogger.i(TAG, "Broadcast received: Playback mode change, full re-initialization requested.")
-                        playheadTime = 0L
+                        resetPlaybackTimeline()
                         initializePlayer() // force Reinit
                     }
 
@@ -235,7 +281,7 @@ class UndeadWallpaperService : WallpaperService() {
                     ACTION_VIDEO_SETTINGS_CHANGED -> {
                         FileLogger.i(TAG, "Broadcast received: Video settings changed, full re-initialization requested.")
                         // Ensure settings apply completely identical to a URI change to avoid syncing bugs
-                        playheadTime = 0L
+                        resetPlaybackTimeline()
                         initializePlayer() // force Reinit
                     }
 
@@ -250,6 +296,8 @@ class UndeadWallpaperService : WallpaperService() {
 
         /**
          * Skips current video and moves to next using chunks to buffer video sharing settings
+         * @param isManualSkip when true, means that the user initiated the action and
+         * matrix changes are not applied on call, but applied later on first frame of the new video.
          */
         private fun skipNextVideo(isManualSkip: Boolean) {
             if (!isPlayerInitialized) return
@@ -270,17 +318,14 @@ class UndeadWallpaperService : WallpaperService() {
 
                 FileLogger.i(TAG, "Single-video mode detected. Performing hard re-initialization for skip.")
                 releasePlayer()
-                playheadTime = 0L
-                hasPlaybackCompleted = false
+                resetPlaybackTimeline()
                 initializePlayer()
                 return
             }
 
             // Now update the state
-            loadedVideoUriString = nextUriString
-            prefs.saveActiveVideoUri(nextUriString)
-            playheadTime = 0L
-            hasPlaybackCompleted = false
+            updateActiveVideoState(nextUriString)
+            resetPlaybackTimeline()
 
             // ALWAYS Hot-swap via Chunking!
             bindPlaylistToPlayer(keepCurrentPlayback = false)
@@ -313,39 +358,7 @@ class UndeadWallpaperService : WallpaperService() {
 
         override fun onTouchEvent(event: MotionEvent?) {
             super.onTouchEvent(event)
-
-            // We only care about the moment the finger hits the screen
-            if (event?.action == MotionEvent.ACTION_DOWN) {
-                val currentTapTimeMs = System.currentTimeMillis()
-
-                // If this tap is within the timeout window of the previous tap
-                if (currentTapTimeMs - lastTapTimeMs < DOUBLE_TAP_TIMEOUT_MS) {
-                    tapCount++
-                } else {
-                    // First tap, or too much time passed. Reset count.
-                    tapCount = 1
-                }
-
-                lastTapTimeMs = currentTapTimeMs
-
-                // Cancel any pending reset
-                touchHandler.removeCallbacks(resetTapCountRunnable)
-
-                if (tapCount == 2) {
-                    // DOUBLE TAP DETECTED!
-                    FileLogger.i(TAG, "Double-tap detected at X:${event.x}, Y:${event.y}")
-
-                    // Reset immediately so a third rapid tap doesn't trigger it again
-                    tapCount = 0
-                    lastTapTimeMs = 0L
-
-                    skipNextVideo(true)
-                } else {
-                    // If it's just a single tap, wait to see if a second one comes.
-                    // If not, reset the counter.
-                    touchHandler.postDelayed(resetTapCountRunnable, DOUBLE_TAP_TIMEOUT_MS)
-                }
-            }
+            gestureManager.onTouchEvent(event)
         }
 
         /**
@@ -369,7 +382,6 @@ class UndeadWallpaperService : WallpaperService() {
         }
 
         // WallpaperPlayerListener implementations
-
         override fun onPlayerError(error: PlaybackException) {
             // Handled mostly by WallpaperPlayer, this is just for non-hardware errors or restart triggers
             Handler(Looper.getMainLooper()).post {
@@ -479,6 +491,9 @@ class UndeadWallpaperService : WallpaperService() {
             if (isPlayerInitialized) {
                 releasePlayer()
             }
+
+            // Allow the OS to send MotionEvents to this engine
+            updateTouchListeningState()
 
             // Get a surface
             val holder = surfaceHolder
@@ -700,6 +715,7 @@ class UndeadWallpaperService : WallpaperService() {
             playbackWatchdog.stop() // Kill the playback watchdog
             releasePlayer()
             releaseRenderer()
+            gestureManager.destroy()
             unregisterReceiver(videoChangeReceiver)
         }
 
@@ -714,7 +730,7 @@ class UndeadWallpaperService : WallpaperService() {
             visibilityJob = kotlinx.coroutines.CoroutineScope(Dispatchers.Main).launch {
                 kotlinx.coroutines.delay(33L) // Give Device 33ms to stop spamming
 
-                // If this job was cancelled by another rapid-fire event, stop here.
+                // If this job was canceled by another rapid-fire event, stop here.
                 if (!isActive) return@launch
 
                 FileLogger.i(TAG, "onVisibilityChanged (Debounced): visible = $visible isPreview = $isPreview, playbackMode = $currentPlaybackMode")
@@ -735,8 +751,7 @@ class UndeadWallpaperService : WallpaperService() {
                         // If the user wants a restart, reset playhead BEFORE init
                         // so bindPlaylistToPlayer doesn't seek to the old paused position.
                         if (prefs.getStartTime() == StartTime.RESTART) {
-                            playheadTime = 0L
-                            hasPlaybackCompleted = false
+                            resetPlaybackTimeline()
                         }
 
                         initializePlayer()
@@ -750,15 +765,11 @@ class UndeadWallpaperService : WallpaperService() {
                         when (startTimePref) {
                             StartTime.RESUME -> {
                                 if (currentPlaybackMode == PlaybackMode.ONE_SHOT && hasPlaybackCompleted && !isPreview()) {
-                                    playheadTime = 0L
-                                    wallpaperPlayer.seekToDefaultPosition()
-                                    hasPlaybackCompleted = false
+                                    resetPlaybackTimeline(seekPlayerToStart = true)
                                 }
                             }
                             StartTime.RESTART -> {
-                                playheadTime = 0L
-                                wallpaperPlayer.seekToDefaultPosition()
-                                hasPlaybackCompleted = false
+                                resetPlaybackTimeline(seekPlayerToStart = true)
                             }
                             StartTime.RANDOM -> {
                                 val duration = wallpaperPlayer.duration
@@ -767,8 +778,7 @@ class UndeadWallpaperService : WallpaperService() {
                                     playheadTime = randomPos
                                     wallpaperPlayer.seekTo(wallpaperPlayer.currentMediaItemIndex, randomPos)
                                 } else {
-                                    playheadTime = 0L
-                                    wallpaperPlayer.seekToDefaultPosition()
+                                    resetPlaybackTimeline()
                                 }
                                 hasPlaybackCompleted = false
                             }
@@ -781,7 +791,8 @@ class UndeadWallpaperService : WallpaperService() {
 
                     // The "Play" Command: Just set the flag.
                     // ExoPlayer will start natively as soon as it reaches STATE_READY.
-                    wallpaperPlayer.playWhenReady = true
+                    // Must be left to pause if user manually paused with touch events
+                    wallpaperPlayer.playWhenReady = !isUserManuallyPaused // leaving it paused on user pause touch event
 
                     wallpaperPlayer.getPlayerInstance()?.let { playerInstance ->
                         playbackWatchdog.start(playerInstance, renderer) // Monitor for playback running
@@ -789,7 +800,7 @@ class UndeadWallpaperService : WallpaperService() {
 
                 } else {
                     playbackWatchdog.stop()
-
+                    gestureManager.destroy()
                     if (isPreview) {
                         FileLogger.i(TAG, "Preview hidden. Releasing player to save decoders.")
                         releasePlayer()

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/WallpaperPlayer.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/WallpaperPlayer.kt
@@ -118,6 +118,27 @@ class WallpaperPlayer(
         return player
     }
 
+    /**
+     * Atomic replace + prepare for skipping chunks.
+     * Loads newMediaSources, attaches them as the sole media list,
+     * seeks to media index 0 position 0, prepares, and returns.
+     * Preserves volume, speed, repeat/shuffle mode, and decoder instances.
+     */
+    @OptIn(UnstableApi::class)
+    fun loadAndPlayNewChunk(newMediaSources: List<MediaSource>) {
+        val p = player ?: return
+
+        p.setMediaSources(newMediaSources)
+        p.seekTo(0, 0L)
+        p.prepare()
+
+        // We do NOT set playWhenReady here. The Engine handles that based on visibility.
+    }
+
+    /**
+     * Main player initialization code,
+     * includes buffering settings, seek mode, and wires events.
+     */
     @OptIn(UnstableApi::class)
     fun initialize(
         surface: Surface?,

--- a/app/src/main/java/org/maocide/undeadwallpaper/ui/SettingsFragment.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/ui/SettingsFragment.kt
@@ -519,7 +519,7 @@ class SettingsFragment : Fragment() {
                 startActivity(intent)
             } catch (e: Exception) {
                 FileLogger.e(tag, "Failed to open app info settings", e)
-                Toast.makeText(requireContext(), "Unable to open settings", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), getString(R.string.error_open_settings_failed), Toast.LENGTH_SHORT).show()
             }
         }
     }
@@ -614,7 +614,7 @@ class SettingsFragment : Fragment() {
             if (!hasWarnedAboutGestures) {
                 Toast.makeText(
                     requireContext(),
-                    "Note: Some launchers may block wallpaper gestures.",
+                    getString(R.string.gesture_launcher_warning),
                     Toast.LENGTH_LONG
                 ).show()
                 hasWarnedAboutGestures = true
@@ -808,7 +808,7 @@ class SettingsFragment : Fragment() {
             if (!isValid) {
                 Toast.makeText(
                     context,
-                    "Video too large! Max supported resolution is 4K (UHD).",
+                    getString(R.string.error_video_too_large),
                     Toast.LENGTH_LONG
                 ).show()
 

--- a/app/src/main/java/org/maocide/undeadwallpaper/ui/SettingsFragment.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/ui/SettingsFragment.kt
@@ -58,6 +58,8 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.upstream.DefaultAllocator
+import org.maocide.undeadwallpaper.model.GestureType
+import org.maocide.undeadwallpaper.model.WallpaperAction
 
 import kotlin.math.roundToInt
 
@@ -76,10 +78,9 @@ class SettingsFragment : Fragment() {
     private val recentFiles = mutableListOf<RecentFile>()
     private var currentVideoDurationMs: Long = 0L
     private var previewPlayer: ExoPlayer? = null
-
-    private var speedValueWarned = false
     private var randomStartTimeWarned = false
     private var isUpdatingUi = false
+    private var hasWarnedAboutGestures = false
 
     // Initialize the shared ViewModel
     private val sharedViewModel: SettingsViewModel by activityViewModels()
@@ -420,7 +421,6 @@ class SettingsFragment : Fragment() {
     /**
      * Update all Buttons/Switches to match Preferences.
      * Calling this BEFORE listeners prevents accidental triggers.
-     * Also called by reset button listener after resetting values
      */
     private suspend fun syncUiState() {
 
@@ -458,6 +458,20 @@ class SettingsFragment : Fragment() {
                 updateVideoSource(savedUri.toUri(), false)
             }
 
+            // Double Tap Gesture
+            when (preferencesManager.getActionForGesture(GestureType.DOUBLE_TAP)) {
+                WallpaperAction.NONE -> binding.doubleTapGroup.check(binding.doubleTapNone.id)
+                WallpaperAction.PLAY_PAUSE -> binding.doubleTapGroup.check(binding.doubleTapPause.id)
+                WallpaperAction.SKIP_NEXT -> binding.doubleTapGroup.check(binding.doubleTapSkip.id)
+            }
+
+            // Triple Tap Gesture
+            when (preferencesManager.getActionForGesture(GestureType.TRIPLE_TAP)) {
+                WallpaperAction.NONE -> binding.tripleTapGroup.check(binding.tripleTapNone.id)
+                WallpaperAction.PLAY_PAUSE -> binding.tripleTapGroup.check(binding.tripleTapPause.id)
+                WallpaperAction.SKIP_NEXT -> binding.tripleTapGroup.check(binding.tripleTapSkip.id)
+            }
+
             // Regardless of having a selected video or not, we need to load the recent files
             // into the RecyclerView adapter ONCE during UI initialization.
             loadRecentFiles()
@@ -469,7 +483,7 @@ class SettingsFragment : Fragment() {
 
 
     /**
-     * Sets up all the listeners for controls.
+     * Updates status for battery card controls.
      */
     private fun checkBatteryOptimization() {
         val context = context ?: return
@@ -486,6 +500,9 @@ class SettingsFragment : Fragment() {
         }
     }
 
+    /**
+     * Sets up the listeners for battery card controls.
+     */
     private fun setupBatteryWarningCard() {
         binding.btnFixBattery.setOnClickListener {
             // Expand the instructions and hide the fix button
@@ -587,6 +604,62 @@ class SettingsFragment : Fragment() {
 
             // Specific intent sent to not reload video
             val intent = Intent(UndeadWallpaperService.ACTION_STATUS_BAR_COLOR_CHANGED).apply {
+                setPackage(requireContext().packageName)
+            }
+            requireContext().applicationContext.sendBroadcast(intent)
+        }
+
+        // Helper function for the warning Toast
+        fun showGestureWarningIfNeeded() {
+            if (!hasWarnedAboutGestures) {
+                Toast.makeText(
+                    requireContext(),
+                    "Note: Some launchers may block wallpaper gestures.",
+                    Toast.LENGTH_LONG
+                ).show()
+                hasWarnedAboutGestures = true
+            }
+        }
+
+        // Double Tap Gesture
+        binding.doubleTapGroup.setOnCheckedStateChangeListener { _, checkedIds ->
+            if (isUpdatingUi || checkedIds.isEmpty()) return@setOnCheckedStateChangeListener
+
+            val action = when (checkedIds[0]) {
+                binding.doubleTapPause.id -> WallpaperAction.PLAY_PAUSE
+                binding.doubleTapSkip.id -> WallpaperAction.SKIP_NEXT
+                else -> WallpaperAction.NONE
+            }
+
+            preferencesManager.setActionForGesture(GestureType.DOUBLE_TAP, action)
+
+            if (action != WallpaperAction.NONE) {
+                showGestureWarningIfNeeded()
+            }
+
+            val intent = Intent(UndeadWallpaperService.ACTION_VIDEO_SETTINGS_CHANGED).apply {
+                setPackage(requireContext().packageName)
+            }
+            requireContext().applicationContext.sendBroadcast(intent)
+        }
+
+        // Triple Tap Gesture
+        binding.tripleTapGroup.setOnCheckedStateChangeListener { _, checkedIds ->
+            if (isUpdatingUi || checkedIds.isEmpty()) return@setOnCheckedStateChangeListener
+
+            val action = when (checkedIds[0]) {
+                binding.tripleTapPause.id -> WallpaperAction.PLAY_PAUSE
+                binding.tripleTapSkip.id -> WallpaperAction.SKIP_NEXT
+                else -> WallpaperAction.NONE
+            }
+
+            preferencesManager.setActionForGesture(GestureType.TRIPLE_TAP, action)
+
+            if (action != WallpaperAction.NONE) {
+                showGestureWarningIfNeeded()
+            }
+
+            val intent = Intent(UndeadWallpaperService.ACTION_VIDEO_SETTINGS_CHANGED).apply {
                 setPackage(requireContext().packageName)
             }
             requireContext().applicationContext.sendBroadcast(intent)
@@ -839,36 +912,6 @@ class SettingsFragment : Fragment() {
         previewPlayer?.release()
         previewPlayer = null
         binding.videoPreview.player = null
-    }
-
-    /**
-     * Safely sets the value of a Material Slider, preventing crashes from out-of-range/step values.
-     *
-     * This extension function ensures that any value assigned to the slider is first clamped
-     * to be within the slider's `valueFrom` and `valueTo` range. If the slider has a `stepSize`
-     * defined, the function will also snap the clamped value to the nearest valid step.
-     *
-     * This is useful for programmatically setting slider values that might come from external
-     * sources (like saved preferences) without causing an `IllegalArgumentException`.
-     *
-     * @param newValue The desired new value for the slider.
-     */
-    fun com.google.android.material.slider.Slider.setValueSafe(newValue: Float) {
-        // Clamp: Ensure value is strictly between valueFrom and valueTo
-        val clampedValue = newValue.coerceIn(valueFrom, valueTo)
-
-        // Snap: If a stepSize is defined, ensure the value fits the step
-        val finalValue = if (stepSize > 0) {
-            // Calculate how many "steps" we are from the start
-            val steps = ((clampedValue - valueFrom) / stepSize).roundToInt()
-            // Reconstruct the value based on exact steps
-            valueFrom + (steps * stepSize)
-        } else {
-            clampedValue
-        }
-
-        // Apply: Only now is it safe to set the value
-        this.value = finalValue
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/maocide/undeadwallpaper/ui/SettingsFragment.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/ui/SettingsFragment.kt
@@ -220,12 +220,14 @@ class SettingsFragment : Fragment() {
         // Get duration and update UI
         currentVideoDurationMs = getVideoDuration(uri)
         if (currentVideoDurationMs == 0L) {
-            // Handle case where duration is invalid or video is corrupt
             Toast.makeText(context, R.string.error_could_not_read_video_duration, Toast.LENGTH_LONG).show()
         }
 
-        // Update the video preview
-        setupVideoPreview(uri)
+        // Only spawn a new player if the user actively clicked
+        // If the app is booting up, onResume will handle it
+        if (isResumed) {
+            setupVideoPreview(uri)
+        }
 
         // Save the preference and notify the service to reload the video from that value
         if(forceChange) {
@@ -235,7 +237,6 @@ class SettingsFragment : Fragment() {
             }
             context?.sendBroadcast(intent)
         }
-
     }
 
 
@@ -454,8 +455,8 @@ class SettingsFragment : Fragment() {
             // Load Video Preview and set the video as selected
             val savedUri = preferencesManager.getActiveVideoUri()
             if (savedUri != null) {
-                //setupVideoPreview(uriString.toUri())
-                updateVideoSource(savedUri.toUri(), false)
+                // onResume() will handle actually creating ExoPlayer safely, updating video source
+                sharedViewModel.selectedVideoUri = savedUri.toUri()
             }
 
             // Double Tap Gesture

--- a/app/src/main/java/org/maocide/undeadwallpaper/ui/VideoSettingsSheet.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/ui/VideoSettingsSheet.kt
@@ -215,14 +215,33 @@ class VideoSettingsSheet : BottomSheetDialogFragment() {
         }
     }
 
+    /**
+     * Safely sets the value of a Material Slider, preventing crashes from out-of-range/step values.
+     *
+     * This extension function ensures that any value assigned to the slider is first clamped
+     * to be within the slider's `valueFrom` and `valueTo` range. If the slider has a `stepSize`
+     * defined, the function will also snap the clamped value to the nearest valid step.
+     *
+     * This is useful for programmatically setting slider values that might come from external
+     * sources (like saved preferences) without causing an `IllegalArgumentException`.
+     *
+     * @param newValue The desired new value for the slider.
+     */
     private fun Slider.setValueSafe(newValue: Float) {
+        // Clamp: Ensure value is strictly between valueFrom and valueTo
         val clampedValue = newValue.coerceIn(valueFrom, valueTo)
+
+        // Snap: If a stepSize is defined, ensure the value fits the step
         val finalValue = if (stepSize > 0) {
+            // Calculate how many "steps" we are from the start
             val steps = ((clampedValue - valueFrom) / stepSize).roundToInt()
+            // Reconstruct the value based on exact steps
             valueFrom + (steps * stepSize)
         } else {
             clampedValue
         }
+
+        // Apply: Only now is it safe to set the value
         this.value = finalValue
     }
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -420,7 +420,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Gesture Controls"
+                    android:text="@string/gesture_controls_header"
                     android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"
                     android:layout_marginBottom="8dp"/>
@@ -430,7 +430,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="Double Tap" />
+                    android:text="@string/double_tap_label" />
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/double_tap_group"
@@ -447,30 +447,30 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:checked="true"
-                        android:text="None" />
+                        android:text="@string/gesture_action_none" />
 
                     <com.google.android.material.chip.Chip
                         android:id="@+id/double_tap_pause"
                         style="@style/Widget.MaterialComponents.Chip.Choice"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Pause/Play" />
+                        android:text="@string/gesture_action_pause_play" />
 
                     <com.google.android.material.chip.Chip
                         android:id="@+id/double_tap_skip"
                         style="@style/Widget.MaterialComponents.Chip.Choice"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Skip" />
+                        android:text="@string/gesture_action_skip" />
 
                 </com.google.android.material.chip.ChipGroup>
 
-                <!-- Double Tap -->
+                <!-- Triple Tap -->
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="Triple Tap" />
+                    android:text="@string/triple_tap_label" />
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/triple_tap_group"
@@ -487,21 +487,21 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:checked="true"
-                        android:text="None" />
+                        android:text="@string/gesture_action_none" />
 
                     <com.google.android.material.chip.Chip
                         android:id="@+id/triple_tap_pause"
                         style="@style/Widget.MaterialComponents.Chip.Choice"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Pause/Play" />
+                        android:text="@string/gesture_action_pause_play" />
 
                     <com.google.android.material.chip.Chip
                         android:id="@+id/triple_tap_skip"
                         style="@style/Widget.MaterialComponents.Chip.Choice"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Skip" />
+                        android:text="@string/gesture_action_skip" />
 
                 </com.google.android.material.chip.ChipGroup>
 
@@ -509,7 +509,6 @@
 
 
         </com.google.android.material.card.MaterialCardView>
-
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/card_playlist"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -400,7 +400,7 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
-            android:id="@+id/card_playlist"
+            android:id="@+id/card_touch_controls"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
@@ -408,6 +408,118 @@
             app:strokeWidth="0dp"
             app:cardElevation="8dp"
             app:layout_constraintTop_toBottomOf="@id/card_settings"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Gesture Controls"
+                    android:textAppearance="?attr/textAppearanceTitleMedium" android:textStyle="bold"
+                    android:textColor="?attr/colorPrimary"
+                    android:layout_marginBottom="8dp"/>
+
+                <!-- Double Tap -->
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="Double Tap" />
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/double_tap_group"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    app:singleSelection="true"
+                    app:selectionRequired="true"
+                    app:chipSpacingHorizontal="8dp">
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/double_tap_none"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="None" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/double_tap_pause"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Pause/Play" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/double_tap_skip"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Skip" />
+
+                </com.google.android.material.chip.ChipGroup>
+
+                <!-- Double Tap -->
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="Triple Tap" />
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/triple_tap_group"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    app:singleSelection="true"
+                    app:selectionRequired="true"
+                    app:chipSpacingHorizontal="8dp">
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/triple_tap_none"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="None" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/triple_tap_pause"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Pause/Play" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/triple_tap_skip"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Skip" />
+
+                </com.google.android.material.chip.ChipGroup>
+
+            </LinearLayout>
+
+
+        </com.google.android.material.card.MaterialCardView>
+
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/card_playlist"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:cardCornerRadius="24dp"
+            app:strokeWidth="0dp"
+            app:cardElevation="8dp"
+            app:layout_constraintTop_toBottomOf="@id/card_touch_controls"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -50,8 +50,8 @@
     <string name="reset">Restablecer</string>
     <string name="rotation">Rotación</string>
 
-    <!-- Gesture Controls -->
-    <string name="gesture_controls_header">Controles de Gestos</string>
+    <!-- Home Screen Gestures -->
+    <string name="gesture_controls_header">Gestos en Inicio</string>
     <string name="double_tap_label">Doble Toque</string>
     <string name="triple_tap_label">Triple Toque</string>
     <string name="gesture_action_none">Ninguno</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -50,6 +50,15 @@
     <string name="reset">Restablecer</string>
     <string name="rotation">Rotación</string>
 
+    <!-- Gesture Controls -->
+    <string name="gesture_controls_header">Controles de Gestos</string>
+    <string name="double_tap_label">Doble Toque</string>
+    <string name="triple_tap_label">Triple Toque</string>
+    <string name="gesture_action_none">Ninguno</string>
+    <string name="gesture_action_pause_play">Pausa/Reproducir</string>
+    <string name="gesture_action_skip">Saltar</string>
+    <string name="gesture_launcher_warning">Nota: Algunos lanzadores pueden bloquear los gestos del fondo de pantalla.</string>
+
     <!-- Error and Warning Messages -->
     <string name="error_permission_failed">No se pudo obtener el permiso para el archivo seleccionado.</string>
     <string name="warning_4k_video">Advertencia: los videos en 4K pueden causar cierres inesperados o lentitud en algunos dispositivos.</string>
@@ -59,6 +68,8 @@
     <string name="error_file_picker_not_available">¡El selector de archivos no está disponible en el sistema!</string>
     <string name="error_could_not_read_video_duration">No se pudo leer la duración del video.</string>
     <string name="warning_random_start_time_delay">Aleatorio puede causar retrasos debido a la búsqueda</string>
+    <string name="error_video_too_large">Video demasiado grande! La resolución máxima admitida es 4K (UHD).</string>
+    <string name="error_open_settings_failed">No se pudieron abrir los ajustes</string>
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">Íconos de la Barra de Estado</string>
     <string name="status_bar_auto">Automático</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -49,8 +49,8 @@
     <string name="reset">Ripristina</string>
     <string name="rotation">Rotazione</string>
 
-    <!-- Gesture Controls -->
-    <string name="gesture_controls_header">Controlli Touch</string>
+    <!-- Home Screen Gestures -->
+    <string name="gesture_controls_header">Controlli Touch sulla Home</string>
     <string name="double_tap_label">Doppio Tap</string>
     <string name="triple_tap_label">Triplo Tap</string>
     <string name="gesture_action_none">Nessuna</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -49,6 +49,15 @@
     <string name="reset">Ripristina</string>
     <string name="rotation">Rotazione</string>
 
+    <!-- Gesture Controls -->
+    <string name="gesture_controls_header">Controlli Touch</string>
+    <string name="double_tap_label">Doppio Tap</string>
+    <string name="triple_tap_label">Triplo Tap</string>
+    <string name="gesture_action_none">Nessuna</string>
+    <string name="gesture_action_pause_play">Pausa/Riproduzione</string>
+    <string name="gesture_action_skip">Salta</string>
+    <string name="gesture_launcher_warning">Nota: Alcuni launcher potrebbero bloccare i gesti dello sfondo.</string>
+
     <!-- Error and Warning Messages -->
     <string name="error_permission_failed">Impossibile ottenere l\'autorizzazione per il file selezionato.</string>
     <string name="warning_4k_video">Attenzione: i video 4K potrebbero causare crash o lag su alcuni dispositivi.</string>
@@ -58,6 +67,8 @@
     <string name="error_file_picker_not_available">Il selettore file non è disponibile nel sistema!</string>
     <string name="error_could_not_read_video_duration">Impossibile leggere la durata del video.</string>
     <string name="warning_random_start_time_delay">Random potrebbe causare ritardi a causa della ricerca</string>
+    <string name="error_video_too_large">Video troppo grande! La risoluzione massima supportata è 4K (UHD).</string>
+    <string name="error_open_settings_failed">Impossibile aprire le impostazioni</string>
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">Icone Barra di Stato</string>
     <string name="status_bar_auto">Automatico</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -48,8 +48,8 @@
     <string name="reset">リセット</string>
     <string name="rotation">回転</string>
 
-    <!-- Gesture Controls -->
-    <string name="gesture_controls_header">ジェスチャ設定</string>
+    <!-- Home Screen Gestures -->
+    <string name="gesture_controls_header">ホーム画面のジェスチャ</string>
     <string name="double_tap_label">ダブルタップ</string>
     <string name="triple_tap_label">トリプルタップ</string>
     <string name="gesture_action_none">なし</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -48,6 +48,15 @@
     <string name="reset">リセット</string>
     <string name="rotation">回転</string>
 
+    <!-- Gesture Controls -->
+    <string name="gesture_controls_header">ジェスチャ設定</string>
+    <string name="double_tap_label">ダブルタップ</string>
+    <string name="triple_tap_label">トリプルタップ</string>
+    <string name="gesture_action_none">なし</string>
+    <string name="gesture_action_pause_play">一時停止/再生</string>
+    <string name="gesture_action_skip">スキップ</string>
+    <string name="gesture_launcher_warning">注: 一部のランチャーでは壁紙のジェスチャがブロックされることがあります。</string>
+
     <!-- Error and Warning Messages -->
     <string name="error_permission_failed">選択したファイルの権限を取得できませんでした。</string>
     <string name="warning_4k_video">警告: 4K動画は一部のデバイスでクラッシュまたは遅延する可能性があります。</string>
@@ -57,7 +66,9 @@
     <string name="error_file_picker_not_available">ファイルピッカーがシステムで利用できません。</string>
     <string name="error_could_not_read_video_duration">動画の長さを読み取れませんでした。</string>
     <string name="warning_random_start_time_delay">ランダムはシークによる遅延を引き起こす可能性があります</string>
+    <string name="error_video_too_large">ビデオが大きすぎます！最大対応解像度は4K（UHD）です。</string>
     <string name="error_cannot_remove_last_video">プレイリストの最後の動画は外せません</string>
+    <string name="error_open_settings_failed">設定を開けませんでした</string>
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">ステータスバーのアイコン</string>
     <string name="status_bar_auto">自動</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,138 @@
+<resources>
+    <string name="app_name">Undead Wallpaper</string>
+    <string name="action_settings">Sobre</string>
+    <string name="action_battery_optimization">Otimização de Bateria</string>
+
+    <!-- Strings used for fragments for navigation -->
+    <string name="first_fragment_label">Configurações do Undead</string>
+    <string name="second_fragment_label">Sobre</string>
+    <string name="previous">Anterior</string>
+
+    <!-- UI Strings -->
+    <string name="pick_video">Escolher Vídeo</string>
+    <string name="trim_video">Cortar Vídeo</string>
+    <string name="setting_audio_enabled">Habilitar Áudio</string>
+    <string name="playback_mode_setting">Modo de Reprodução</string>
+    <string name="recent_files">Playlist / Arquivos Recentes</string>
+    <string name="playlist_instructions">Toque longo para reordenar. Deslize para esquerda ou direita para remover.</string>
+    <string name="error_cannot_remove_last_video">Não é possível remover o último vídeo da playlist.</string>
+    <string name="apply_trim">Aplicar</string>
+    <string name="wallpaper_description">Um wallpaper vivo que reproduz vídeos.</string>
+    <string name="activating_wallpaper_message">Ativando wallpaper…</string>
+    <string name="select_video_first_message">Por favor, escolha um vídeo primeiro</string>
+
+    <!-- SharedPreferences Keys. These are not meant for translation. -->
+    <string name="video_uri" translatable="false">video_uri</string>
+    <string name="video_audio_enabled" translatable="false">video_audio_enabled</string>
+    <string name="playback_mode" translatable="false">playback_mode</string>
+    <string name="video_zoom_level" translatable="false">video_zoom_level</string>
+    <string name="video_start_ms" translatable="false">video_start_ms</string>
+    <string name="video_end_ms" translatable="false">video_end_ms</string>
+
+    <string name="default_video_filename" translatable="false">zombillie_default.mp4</string>
+    <string name="profile_image_content_description">Foto de perfil do desenvolvedor</string>
+    <string name="github_profile_text"><![CDATA[<a href="https://github.com/maocide/">GitHub: maocide</a>]]></string>
+    <string name="license_text"><![CDATA[<a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licença: GNU GPL v3.0</a>]]></string>
+
+    <!-- About Page Strings -->
+    <string name="about_header_story">A História Por Trás do Nome</string>
+    <string name="about_story_content">Isso não é apenas um trocadilho inteligente com wallpaper <b>vivo</b>. O nome <b>UndeadWallpaper</b> é pessoal. Depois de uma longa e forçada pausa na programação, este projeto foi o primeiro sinal de vida—o momento em que uma paixão que estava enterrada voltou com força à tona. Este app não é apenas <b>vivo</b>; é o símbolo de um criador voltando dos mortos. É <b>imortal</b>, porque algumas coisas são simplesmente teimosas demais para morrer.</string>
+    <string name="about_header_features">O Que Ele Faz</string>
+    <string name="about_feature_loops">• Loops Suaves: Transforma qualquer vídeo do seu telefone em um wallpaper vivo contínuo e sem travamentos.</string>
+    <string name="about_feature_freedom">• Liberdade Total: Sem anúncios, sem compras no app, sem merda. Nunca.</string>
+    <string name="about_feature_control">• Você Está no Controle: Suporta alternância de áudio e rastreia seus vídeos recentes para trocas rápidas.</string>
+    <string name="playback_mode_loop">Repetir</string>
+    <string name="playback_mode_oneshot">Uma Vez</string>
+    <string name="playback_mode_loop_all">Repetir Todos</string>
+    <string name="playback_mode_shuffle">Aleatório</string>
+    <string name="scaling_mode">Modo de Redimensionamento</string>
+    <string name="scaling_mode_fit">Ajustar</string>
+    <string name="scaling_mode_fill">Preencher</string>
+    <string name="scaling_mode_stretch">Esticar</string>
+    <string name="advanced">Avançado</string>
+    <string name="horizontal_position">Posição Horizontal</string>
+    <string name="vertical_position">Posição Vertical</string>
+    <string name="zoom">Zoom</string>
+    <string name="brightness">Brilho</string>
+    <string name="speed">Velocidade</string>
+    <string name="reset">Redefinir</string>
+    <string name="rotation">Rotação</string>
+
+    <!-- Gesture Controls -->
+    <string name="gesture_controls_header">Controles de Gestos</string>
+    <string name="double_tap_label">Toque Duplo</string>
+    <string name="triple_tap_label">Toque Triplo</string>
+    <string name="gesture_action_none">Nenhum</string>
+    <string name="gesture_action_pause_play">Pausar/Reproduzir</string>
+    <string name="gesture_action_skip">Pular</string>
+    <string name="gesture_launcher_warning">Nota: Alguns lançadores podem bloquear os gestos do wallpaper.</string>
+
+    <!-- Error and Warning Messages -->
+    <string name="error_permission_failed">Falha ao obter permissão para o arquivo selecionado.</string>
+    <string name="warning_4k_video">Aviso: vídeos 4K podem travar ou causar atrasos em alguns dispositivos.</string>
+    <string name="error_copy_failed">Falha ao copiar o arquivo de vídeo.</string>
+    <string name="error_cannot_play_video">Não é possível reproduzir este arquivo de vídeo.</string>
+    <string name="warning_high_speed_stuttering">Velocidades altas podem causar travamentos em vídeos de alta resolução.</string>
+    <string name="error_file_picker_not_available">O seletor de arquivos não está disponível no sistema!</string>
+    <string name="error_could_not_read_video_duration">Não foi possível ler a duração do vídeo.</string>
+    <string name="warning_random_start_time_delay">Aleatório pode causar atraso devido ao seek</string>
+    <string name="error_video_too_large">Vídeo muito grande! A resolução máxima suportada é 4K (UHD).</string>
+    <string name="error_open_settings_failed">Falha ao abrir as configurações</string>
+    <!-- Status Bar Icon Color Settings -->
+    <string name="status_bar_icons_label">Ícones da Barra de Status</string>
+    <string name="status_bar_auto">Automático</string>
+    <string name="status_bar_white_icons">Branco</string>
+    <string name="status_bar_black_icons">Preto</string>
+
+    <!-- UI Headers & Sections -->
+    <string name="custom_settings_header">Configurações Personalizadas</string>
+    <string name="positioning_header">Posicionamento</string>
+    <string name="general_header">Geral</string>
+    <string name="volume_label">Volume</string>
+    <string name="global_settings_header">Configurações Globais</string>
+    <string name="debug_options_header">Opções de Depuração</string>
+    <string name="debug_logging_description">Habilite o registro em arquivo local para capturar crashes complexos. É recomendado deixar isso desativado a menos que você esteja enfrentando problemas.</string>
+    <string name="debug_enable_logging">Habilitar Registro Local</string>
+    <string name="debug_clear_log">Limpar Registro</string>
+    <string name="debug_share_log">Compartilhar Registro</string>
+
+    <!-- Start Time Settings -->
+    <string name="start_time_label">Ao Visível</string>
+    <string name="start_time_resume">Continuar</string>
+    <string name="start_time_restart">Reiniciar</string>
+    <string name="start_time_random">Aleatório</string>
+
+    <string name="breadcrumb_zoom">Zoom</string>
+    <string name="breadcrumb_pan">Pan</string>
+    <string name="breadcrumb_rotation">Rotação</string>
+    <string name="breadcrumb_brightness">Brilho</string>
+    <string name="breadcrumb_speed">Velocidade</string>
+    <string name="breadcrumb_volume">Volume</string>
+    <string name="breadcrumb_more">+%1$d mais</string>
+
+    <string name="remove_file_title">Remover Vídeo</string>
+    <string name="remove_file_message">Tem certeza que deseja remover %s do app?</string>
+    <string name="remove_action">Remover</string>
+    <string name="cancel">Cancelar</string>
+
+    <!-- Battery Optimization Warning -->
+    <string name="battery_warning_title">Permitir Desempenho em Segundo Plano</string>
+    <string name="battery_warning_desc">Permita que o Undead Wallpaper seja executado em segundo plano para evitar que o sistema o encerre.</string>
+    <string name="battery_warning_btn">Corrigir</string>
+    <string name="battery_instruction_step_1">1. Toque em Uso de Bateria do App</string>
+    <string name="battery_instruction_step_2">2. Toque em Permitir Uso em Segundo Plano</string>
+    <string name="battery_instruction_step_3">3. Permita e Selecione Sem Restrições</string>
+    <string name="battery_warning_go_to_settings">Ir para Configurações</string>
+
+    <!-- Debug Logger -->
+    <string name="log_enabled_toast">Registro em arquivo local habilitado</string>
+    <string name="log_disabled_toast">Registro em arquivo local desabilitado</string>
+    <string name="share_log_title">Compartilhar Registro de Depuração</string>
+    <string name="share_log_warning">O registro de depuração pode conter informações sensíveis como nomes de arquivos ou detalhes do dispositivo. Tem certeza que deseja compartilhá-lo?</string>
+    <string name="share_log_confirm">Compartilhar</string>
+    <string name="share_log_cancel">Cancelar</string>
+    <string name="share_log_intent_title">Compartilhar Registro de Depuração</string>
+    <string name="log_empty_toast">Arquivo de registro não encontrado ou vazio</string>
+    <string name="log_cleared_toast">Arquivo de registro limpo</string>
+
+</resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -14,7 +14,7 @@
     <string name="setting_audio_enabled">Habilitar Áudio</string>
     <string name="playback_mode_setting">Modo de Reprodução</string>
     <string name="recent_files">Playlist / Arquivos Recentes</string>
-    <string name="playlist_instructions">Toque longo para reordenar. Deslize para esquerda ou direita para remover.</string>
+    <string name="playlist_instructions">Toque longo para reordenar. Deslize para a esquerda ou direita para remover.</string>
     <string name="error_cannot_remove_last_video">Não é possível remover o último vídeo da playlist.</string>
     <string name="apply_trim">Aplicar</string>
     <string name="wallpaper_description">Um wallpaper vivo que reproduz vídeos.</string>
@@ -39,7 +39,7 @@
     <string name="about_story_content">Isso não é apenas um trocadilho inteligente com wallpaper <b>vivo</b>. O nome <b>UndeadWallpaper</b> é pessoal. Depois de uma longa e forçada pausa na programação, este projeto foi o primeiro sinal de vida—o momento em que uma paixão que estava enterrada voltou com força à tona. Este app não é apenas <b>vivo</b>; é o símbolo de um criador voltando dos mortos. É <b>imortal</b>, porque algumas coisas são simplesmente teimosas demais para morrer.</string>
     <string name="about_header_features">O Que Ele Faz</string>
     <string name="about_feature_loops">• Loops Suaves: Transforma qualquer vídeo do seu telefone em um wallpaper vivo contínuo e sem travamentos.</string>
-    <string name="about_feature_freedom">• Liberdade Total: Sem anúncios, sem compras no app, sem merda. Nunca.</string>
+    <string name="about_feature_freedom">• Liberdade Total: Sem anúncios, sem compras no app, sem frescura. Nunca.</string>
     <string name="about_feature_control">• Você Está no Controle: Suporta alternância de áudio e rastreia seus vídeos recentes para trocas rápidas.</string>
     <string name="playback_mode_loop">Repetir</string>
     <string name="playback_mode_oneshot">Uma Vez</string>
@@ -58,14 +58,14 @@
     <string name="reset">Redefinir</string>
     <string name="rotation">Rotação</string>
 
-    <!-- Gesture Controls -->
-    <string name="gesture_controls_header">Controles de Gestos</string>
+    <!-- Home Screen Gestures -->
+    <string name="gesture_controls_header">Gestos na Inicial</string>
     <string name="double_tap_label">Toque Duplo</string>
     <string name="triple_tap_label">Toque Triplo</string>
     <string name="gesture_action_none">Nenhum</string>
     <string name="gesture_action_pause_play">Pausar/Reproduzir</string>
     <string name="gesture_action_skip">Pular</string>
-    <string name="gesture_launcher_warning">Nota: Alguns lançadores podem bloquear os gestos do wallpaper.</string>
+    <string name="gesture_launcher_warning">Nota: Alguns launchers podem bloquear os gestos do wallpaper.</string>
 
     <!-- Error and Warning Messages -->
     <string name="error_permission_failed">Falha ao obter permissão para o arquivo selecionado.</string>
@@ -75,7 +75,7 @@
     <string name="warning_high_speed_stuttering">Velocidades altas podem causar travamentos em vídeos de alta resolução.</string>
     <string name="error_file_picker_not_available">O seletor de arquivos não está disponível no sistema!</string>
     <string name="error_could_not_read_video_duration">Não foi possível ler a duração do vídeo.</string>
-    <string name="warning_random_start_time_delay">Aleatório pode causar atraso devido ao seek</string>
+    <string name="warning_random_start_time_delay">O modo aleatório pode causar atrasos devido à busca no vídeo</string>
     <string name="error_video_too_large">Vídeo muito grande! A resolução máxima suportada é 4K (UHD).</string>
     <string name="error_open_settings_failed">Falha ao abrir as configurações</string>
     <!-- Status Bar Icon Color Settings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,15 @@
     <string name="reset">Reset</string>
     <string name="rotation">Rotation</string>
 
+    <!-- Gesture Controls -->
+    <string name="gesture_controls_header">Gesture Controls</string>
+    <string name="double_tap_label">Double Tap</string>
+    <string name="triple_tap_label">Triple Tap</string>
+    <string name="gesture_action_none">None</string>
+    <string name="gesture_action_pause_play">Pause/Play</string>
+    <string name="gesture_action_skip">Skip</string>
+    <string name="gesture_launcher_warning">Note: Some launchers may block wallpaper gestures.</string>
+
     <!-- Error and Warning Messages -->
     <string name="error_permission_failed">Failed to get permission for the selected file.</string>
     <string name="warning_4k_video">Warning: 4K videos may crash or lag on some devices.</string>
@@ -69,6 +78,8 @@
     <string name="error_file_picker_not_available">File picker not available in the system!</string>
     <string name="error_could_not_read_video_duration">Could not read video duration.</string>
     <string name="warning_random_start_time_delay">Random might cause delay due to seek</string>
+    <string name="error_video_too_large">Video too large! Max supported resolution is 4K (UHD).</string>
+    <string name="error_open_settings_failed">Unable to open settings</string>
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">Status Bar Icons</string>
     <string name="status_bar_auto">Auto</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,8 +60,8 @@
     <string name="reset">Reset</string>
     <string name="rotation">Rotation</string>
 
-    <!-- Gesture Controls -->
-    <string name="gesture_controls_header">Gesture Controls</string>
+    <!-- Home Screen Gestures -->
+    <string name="gesture_controls_header">Home Screen Gestures</string>
     <string name="double_tap_label">Double Tap</string>
     <string name="triple_tap_label">Triple Tap</string>
     <string name="gesture_action_none">None</string>


### PR DESCRIPTION
Features
- feat: Implement skip, DRY engine refactor, and gesture foundations
- feat: Implement multi-tap gesture manager, DRY timeline, and Gesture UI
- i18n: Externalize hardcoded gesture control strings, add 9 new resources (ja, it, es translations)
- i18n: Added pt-BR language translation, bumped version number/code

Fixes
- fix: Implemented ExoPlayer race condition on resume, cached playlist settings
- fix: Funtouch OS / Vivo compatibility, "Home Screen Gestures" i18n, pt-BR polish
- fix: Prevented sticky manual pause when gesture action unbound
- fix: force unpause when user changes settings
- fix: Removed refreshRendered from initialization for better video sync, runs of first video frame

Docs
- docs: Added The Horde's Survival Guide (FAQ)
- docs: FAQ updated with info about launchers not showing live wallpaper in background