### PR TITLE
Add Help / FAQ menu; fix silent decoder death on service wake-up

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "org.maocide.undeadwallpaper"
         minSdk = 28
         targetSdk = 36
-        versionCode = 43
-        versionName = "1.3.5"
+        versionCode = 44
+        versionName = "1.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/UndeadWallpaperService.kt
@@ -794,16 +794,18 @@ class UndeadWallpaperService : WallpaperService() {
                     val isSurfaceDead = surfaceHolder?.surface?.isValid != true
                     var wasJustInitialized = false
 
-                    // Check if we need to (re)initialize
-                    if (currentUriOnDisk != loadedVideoUriString || !isPlayerInitialized || isSurfaceDead) {
-                        if (currentUriOnDisk != loadedVideoUriString) {
+                    // Check if player is initialized AND if the internal thread survived the sleep
+                    val isThreadDead = isPlayerInitialized && !wallpaperPlayer.isPlaybackThreadAlive
+                    if (currentUriOnDisk != loadedVideoUriString || !isPlayerInitialized || isSurfaceDead || isThreadDead) {
+                        if (isThreadDead) {
+                            FileLogger.e(TAG, "WakeUp Check: ExoPlayer internal thread was killed by OS. Forcing restart.")
+                        } else if (currentUriOnDisk != loadedVideoUriString) {
                             FileLogger.i(TAG, "WakeUp Check: URI changed while sleeping! Reloading.")
                         } else if (isSurfaceDead) {
                             FileLogger.w(TAG, "WakeUp Check: Surface died silently. Forcing restart.")
                         }
 
                         // If the user wants a restart, reset playhead BEFORE init
-                        // so bindPlaylistToPlayer doesn't seek to the old paused position.
                         if (prefs.getStartTime() == StartTime.RESTART) {
                             resetPlaybackTimeline()
                         }

--- a/app/src/main/java/org/maocide/undeadwallpaper/service/WallpaperPlayer.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/service/WallpaperPlayer.kt
@@ -72,6 +72,10 @@ class WallpaperPlayer(
             player?.videoScalingMode = value
         }
 
+    val isPlaybackThreadAlive: Boolean
+        @OptIn(UnstableApi::class)
+        get() = player?.playbackLooper?.thread?.isAlive ?: false
+
     @OptIn(UnstableApi::class)
     fun setMediaSources(mediaSources: List<MediaSource>) {
         player?.setMediaSources(mediaSources)

--- a/app/src/main/java/org/maocide/undeadwallpaper/ui/MainActivity.kt
+++ b/app/src/main/java/org/maocide/undeadwallpaper/ui/MainActivity.kt
@@ -25,8 +25,7 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.google.android.material.snackbar.Snackbar
-
-
+import androidx.core.net.toUri
 
 
 class MainActivity : AppCompatActivity() {
@@ -83,11 +82,22 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
         val navController = findNavController(R.id.nav_host_fragment_content_main)
         return when (item.itemId) {
+            R.id.action_faq -> {
+                try {
+                    val intent = Intent(Intent.ACTION_VIEW).apply {
+                        data =
+                            "https://github.com/maocide/UndeadWallpaper/blob/master/FAQ.md".toUri()
+                    }
+                    startActivity(intent)
+                } catch (e: Exception) {
+                    FileLogger.e("MainActivity", "Failed to open FAQ browser link", e)
+                    
+                    Toast.makeText(this, getString(R.string.error_no_browser), Toast.LENGTH_SHORT).show()
+                }
+                true
+            }
             R.id.action_battery_optimization -> {
                 try {
                     val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -2,11 +2,19 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="org.maocide.undeadwallpaper.ui.MainActivity">
+
+    <item
+        android:id="@+id/action_faq"
+        android:orderInCategory="40"
+        android:title="@string/action_faq"
+        app:showAsAction="never" />
+
     <item
         android:id="@+id/action_battery_optimization"
         android:orderInCategory="50"
         android:title="@string/action_battery_optimization"
         app:showAsAction="never" />
+
     <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,6 +3,7 @@
     <string name="app_name">Undead Wallpaper</string>
     <string name="action_settings">Acerca de</string>
     <string name="action_battery_optimization">Optimización de Batería</string>
+    <string name="action_faq">Ayuda / FAQ</string>
 
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">Ajustes de Undead</string>
@@ -70,6 +71,8 @@
     <string name="warning_random_start_time_delay">Aleatorio puede causar retrasos debido a la búsqueda</string>
     <string name="error_video_too_large">Video demasiado grande! La resolución máxima admitida es 4K (UHD).</string>
     <string name="error_open_settings_failed">No se pudieron abrir los ajustes</string>
+    <string name="error_no_browser">No se puede abrir el navegador</string>
+
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">Íconos de la Barra de Estado</string>
     <string name="status_bar_auto">Automático</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Undead Wallpaper</string>
     <string name="action_settings">Informazioni</string>
     <string name="action_battery_optimization">Ottimizzazione Batteria</string>
+    <string name="action_faq">Aiuto / FAQ</string>
 
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">Impostazioni Undead</string>
@@ -69,6 +70,8 @@
     <string name="warning_random_start_time_delay">Random potrebbe causare ritardi a causa della ricerca</string>
     <string name="error_video_too_large">Video troppo grande! La risoluzione massima supportata è 4K (UHD).</string>
     <string name="error_open_settings_failed">Impossibile aprire le impostazioni</string>
+    <string name="error_no_browser">Impossibile aprire il browser</string>
+
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">Icone Barra di Stato</string>
     <string name="status_bar_auto">Automatico</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Undead Wallpaper</string>
     <string name="action_settings">情報</string>
     <string name="action_battery_optimization">バッテリーの最適化</string>
+    <string name="action_faq">ヘルプ / FAQ</string>
 
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">Undead設定</string>
@@ -69,6 +70,8 @@
     <string name="error_video_too_large">ビデオが大きすぎます！最大対応解像度は4K（UHD）です。</string>
     <string name="error_cannot_remove_last_video">プレイリストの最後の動画は外せません</string>
     <string name="error_open_settings_failed">設定を開けませんでした</string>
+    <string name="error_no_browser">ブラウザを開けません</string>
+
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">ステータスバーのアイコン</string>
     <string name="status_bar_auto">自動</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Undead Wallpaper</string>
     <string name="action_settings">O Undead</string>
     <string name="action_battery_optimization">Optymalizacja Baterii</string>
+    <string name="action_faq">Pomoc / FAQ</string>
 
     <string name="first_fragment_label">Ustawienia Undead</string>
     <string name="second_fragment_label">O Undead</string>
@@ -74,6 +75,7 @@
     <string name="warning_random_start_time_delay">Tryb losowy może powodować opóźnienia</string>
     <string name="error_video_too_large">Wideo jest za duże! Maksymalna obsługiwana rozdzielczość to 4K (UHD).</string>
     <string name="error_open_settings_failed">Nie udało się otworzyć ustawień</string>
+    <string name="error_no_browser">Nie można otworzyć przeglądarki</string>
 
     <string name="status_bar_icons_label">Ikony paska stanu</string>
     <string name="status_bar_auto">Auto</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Undead Wallpaper</string>
     <string name="action_settings">Sobre</string>
     <string name="action_battery_optimization">Otimização de Bateria</string>
+    <string name="action_faq">Ajuda / FAQ</string>
 
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">Configurações do Undead</string>
@@ -78,6 +79,8 @@
     <string name="warning_random_start_time_delay">O modo aleatório pode causar atrasos devido à busca no vídeo</string>
     <string name="error_video_too_large">Vídeo muito grande! A resolução máxima suportada é 4K (UHD).</string>
     <string name="error_open_settings_failed">Falha ao abrir as configurações</string>
+    <string name="error_no_browser">Não foi possível abrir o navegador</string>
+
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">Ícones da Barra de Status</string>
     <string name="status_bar_auto">Automático</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Undead Wallpaper</string>
     <string name="action_settings">About</string>
     <string name="action_battery_optimization">Battery Optimization</string>
+    <string name="action_faq">Help / FAQ</string>
 
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">Undead Settings</string>
@@ -80,6 +81,8 @@
     <string name="warning_random_start_time_delay">Random might cause delay due to seek</string>
     <string name="error_video_too_large">Video too large! Max supported resolution is 4K (UHD).</string>
     <string name="error_open_settings_failed">Unable to open settings</string>
+    <string name="error_no_browser">Unable to open browser</string>
+
     <!-- Status Bar Icon Color Settings -->
     <string name="status_bar_icons_label">Status Bar Icons</string>
     <string name="status_bar_auto">Auto</string>


### PR DESCRIPTION
- Add isPlaybackThreadAlive check to WallpaperPlayer exposing ExoPlayer's playbackLooper thread state
- Detect and recover from OS-killed playback thread in onWakeUpCheck, preventing stuck wallpaper after sleep
- Add "Help / FAQ" menu item opening the GitHub FAQ page
- Localize action_faq and error_no_browser across all 6 locales
- Use string resource for browser-not-available toast
- Bump version to 1.3.6 (versionCode 44)